### PR TITLE
Chore: api 서버 도커 컨테이너 8080 포트포워딩 제거

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,6 @@ services:
   dnd-server:
     image: "${REGISTRY_URL}/dnd-server:latest"
     container_name: dnd
-    ports:
-      - "8080:8080"
     networks:
       - dnd
     restart: on-failure


### PR DESCRIPTION
## #️⃣ 연관된 이슈


## 🚀 작업 내용
api 서버는 nginx를 이용해 리버스 프록시가 적용됐으므로 기존에 8080 포트로 도커 컨테이너를 포트포워딩했던 설정을 제거했습니다.

## 💬 리뷰 요구사항(선택)

