### PR TITLE
Chore/#23: 배포 관련 재설정

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -3,7 +3,7 @@ name: Deploy To EC2
 on:
   push:
     branches:
-      - develop
+      - Chore/#23
 
 jobs:
   deploy:
@@ -17,6 +17,9 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
+
+      - name: application-secret.yml 파일 만들기
+        run: echo "${{ secrets.APPLICATION_SECRET }}" > ./src/main/resources/application-secret.yml
 
       - name: 테스트 및 빌드하기
         run: ./gradlew clean build

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -3,7 +3,7 @@ name: Deploy To EC2
 on:
   push:
     branches:
-      - Chore/#23
+      - develop
 
 jobs:
   deploy:

--- a/src/main/java/com/dnd/snappy/domain/common/BaseEntity.java
+++ b/src/main/java/com/dnd/snappy/domain/common/BaseEntity.java
@@ -7,7 +7,9 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -16,6 +18,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder(toBuilder = true)
 public class BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,11 +1,17 @@
 server:
   port: 8080
 spring:
+  profiles:
+    active: dev
+    include: secret
+
+---
+spring:
+  config:
+    activate:
+      on-profile: dev
   transaction:
     default-timeout: '${custom.transaction.default-timeout}'
-  profiles:
-    active: prod
-    include: secret
   datasource:
     hikari:
       maximum-pool-size: '${custom.hikari.maximum-pool-size}'
@@ -23,4 +29,26 @@ spring:
         show_sql: true
         use_sql_comments: true
         default_batch_fetch_size: 1000
+    defer-datasource-initialization: true
+
+---
+spring:
+  config:
+    activate:
+      on-profile: test
+
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:test
+    username: h2
+    password:
+  jpa:
+    properties:
+      hibernate:
+        default_batch_fetch_size: 1000
+        format_sql: true
+        show_sql: true
+        dialect: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create
     defer-datasource-initialization: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -48,7 +48,6 @@ spring:
         default_batch_fetch_size: 1000
         format_sql: true
         show_sql: true
-        dialect: org.hibernate.dialect.H2Dialect
     hibernate:
       ddl-auto: create
     defer-datasource-initialization: true

--- a/src/test/java/com/dnd/snappy/SnappyApplicationTests.java
+++ b/src/test/java/com/dnd/snappy/SnappyApplicationTests.java
@@ -2,8 +2,10 @@ package com.dnd.snappy;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class SnappyApplicationTests {
 
 	@Test

--- a/src/test/java/com/dnd/snappy/config/ApiDocumentUtils.java
+++ b/src/test/java/com/dnd/snappy/config/ApiDocumentUtils.java
@@ -1,6 +1,7 @@
 package com.dnd.snappy.config;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
@@ -11,6 +12,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
+@Import(RestDocsConfiguration.class)
 @Component
 public class ApiDocumentUtils {
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호
#23 

## 🚀 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

CI 과정에서 gradle clean build시 테스트가 실패하여 해당 에러 고쳤습니다!  
- 테스트 환경에서 데이터베이스 접근시 메모리 데이터베이스가 아닌 실제 데이터베이스에 접근하여 에러가 나 이부분 고쳐줬습니다.
   - application yml 파일을 dev 프로필과 test 프로필로 나눴습니다. 
   - SnappyApplicationTests 클래스에 test 프로필 사용을 위해 @ ActiveProfiles("test") 어노테이션 달아주었습니다.
    
- 테스트시 ApiDocumentUtils에서 RestDocumentationResultHandler를 주입받는 과정에서 NoSuchBean 에러가 떠 
@ Import(RestDocsConfiguration.class)를 붙여 해결해 주었습니다.

- github action 실행시 application_secret.yml 파일이 없어 (gitignore) 이부분 rds에 접근하도록 환경변수로 만들어 빌드시 application_secret.yml파일 생기게 해주었습니다. 

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
