### PR TITLE
feat: 관리자 인증키 검증 api 구현 (#43)

### DIFF
--- a/src/docs/asciidoc/meeting/validate-meeting-password-leader.adoc
+++ b/src/docs/asciidoc/meeting/validate-meeting-password-leader.adoc
@@ -1,4 +1,4 @@
-=== 모임 암호 검증 [모임장]
+=== 모임 관리자 인증키 검증
 ==== 성공
 Request
 include::{snippets}/meeting-controller-test/validate-meeting-leader-auth-key/http-request.adoc[]
@@ -11,8 +11,6 @@ include::{snippets}/meeting-controller-test/validate-meeting-leader-auth-key/res
 
 
 ==== 실패
-===== `모임의 비밀번호가 틀린경우`
-include::{snippets}/meeting-controller-test/validate-meeting-leader-auth-key_invalidate-password/http-response.adoc[]
 
 ===== `모임의 관리자 인증키가 틀린경우`
 include::{snippets}/meeting-controller-test/validate-meeting-leader-auth-key_invalidate-leader-auth-key/http-response.adoc[]

--- a/src/docs/asciidoc/meeting/validate-meeting-password.adoc
+++ b/src/docs/asciidoc/meeting/validate-meeting-password.adoc
@@ -1,4 +1,4 @@
-=== 모임 암호 검증 [맴버]
+=== 모임 암호 검증
 ==== 성공
 Request
 include::{snippets}/meeting-controller-test/validate-meeting-password/http-request.adoc[]

--- a/src/main/java/com/dnd/snappy/controller/v1/auth/interceptor/config/InterceptorConfig.java
+++ b/src/main/java/com/dnd/snappy/controller/v1/auth/interceptor/config/InterceptorConfig.java
@@ -18,7 +18,8 @@ public class InterceptorConfig implements WebMvcConfigurer {
         // 이 인터셉터가 적용될 경로 패턴 지정
         registry.addInterceptor(meetingParticipationInterceptor)
                 .addPathPatterns("/api/**/meetings/{meetingId}/**")
-                .excludePathPatterns("/api/**/meetings/{meetingId}/validate-password/**")
+                .excludePathPatterns("/api/**/meetings/{meetingId}/validate-password")
+                .excludePathPatterns("/api/**/meetings/{meetingId}/validate-leader-key")
                 .excludePathPatterns("/api/**/meetings/{meetingId}/share")
                 .excludePathPatterns("/api/**/meetings/{meetingId}/tokens/refresh");
     }

--- a/src/main/java/com/dnd/snappy/controller/v1/meeting/MeetingController.java
+++ b/src/main/java/com/dnd/snappy/controller/v1/meeting/MeetingController.java
@@ -2,6 +2,7 @@ package com.dnd.snappy.controller.v1.meeting;
 
 import com.dnd.snappy.common.dto.ResponseDto;
 import com.dnd.snappy.controller.v1.meeting.request.LeaderAuthKeyValidationRequest;
+import com.dnd.snappy.controller.v1.meeting.request.LeaderValidationRequest;
 import com.dnd.snappy.controller.v1.meeting.request.PasswordValidationRequest;
 import com.dnd.snappy.domain.meeting.dto.request.CreateMeetingRequestDto;
 import com.dnd.snappy.domain.meeting.dto.response.CreateMeetingResponseDto;
@@ -44,12 +45,12 @@ public class MeetingController {
         return ResponseDto.ok();
     }
 
-    @PostMapping("/{meetingId}/validate-password/leader")
+    @PostMapping("/{meetingId}/validate-leader-key")
     public ResponseEntity<ResponseDto<?>> validateMeetingAuthKey(
             @PathVariable("meetingId") Long meetingId,
             @Valid @RequestBody LeaderAuthKeyValidationRequest leaderAuthKeyValidationRequest
     ) {
-        meetingService.validateMeetingLeaderAuthKey(meetingId, leaderAuthKeyValidationRequest.password(), leaderAuthKeyValidationRequest.leaderAuthKey());
+        meetingService.validateMeetingLeaderAuthKey(meetingId, leaderAuthKeyValidationRequest.leaderAuthKey());
         return ResponseDto.ok();
     }
 

--- a/src/main/java/com/dnd/snappy/controller/v1/meeting/request/LeaderValidationRequest.java
+++ b/src/main/java/com/dnd/snappy/controller/v1/meeting/request/LeaderValidationRequest.java
@@ -2,7 +2,9 @@ package com.dnd.snappy.controller.v1.meeting.request;
 
 import jakarta.validation.constraints.NotBlank;
 
-public record LeaderAuthKeyValidationRequest(
+public record LeaderValidationRequest(
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        String password,
         @NotBlank(message = "관리자 인증키는 필수입니다.")
         String leaderAuthKey
 ) {

--- a/src/main/java/com/dnd/snappy/domain/meeting/entity/Meeting.java
+++ b/src/main/java/com/dnd/snappy/domain/meeting/entity/Meeting.java
@@ -97,8 +97,8 @@ public class Meeting extends BaseEntity {
         return this.password.equals(password);
     }
 
-    public boolean isLeaderAuthKeyValid(String password, String leaderAuthKey) {
-        return isCorrectPassword(password) && this.leaderAuthKey.equals(leaderAuthKey);
+    public boolean isCorrectLeaderAuthKey(String leaderAuthKey) {
+        return this.leaderAuthKey.equals(leaderAuthKey);
     }
 
     public boolean canJoinMeeting() {

--- a/src/main/java/com/dnd/snappy/domain/meeting/exception/MeetingErrorCode.java
+++ b/src/main/java/com/dnd/snappy/domain/meeting/exception/MeetingErrorCode.java
@@ -12,6 +12,7 @@ public enum MeetingErrorCode implements ErrorCodeInterface {
     MEETING_LINK_NOT_FOUND(HttpStatus.NOT_FOUND, "MEETING_LINK_NOT_FOUND", "요청된 모임 링크를 찾을 수 없습니다."),
     MEETING_NOT_FOUND(HttpStatus.NOT_FOUND, "MEETING_NOT_FOUND", "요청된 모임을 찾을 수 없습니다."),
     MEETING_INVALIDATE_PASSWORD(HttpStatus.BAD_REQUEST, "MEETING_INVALIDATE_PASSWORD", "모임의 비밀번호가 유효하지 않습니다."),
+    MEETING_INVALIDATE_AUTH_KEY(HttpStatus.BAD_REQUEST, "MEETING_INVALIDATE_AUTH_KEY", "모임의 관리자 인증키가 유효하지 않습니다."),
     MEETING_JOIN_DENIED(HttpStatus.FORBIDDEN, "MEETING_JOIN_DENIED", "이미 끝난 모임에는 참여할 수 없습니다."),
     DUPLICATION_MEETING_LINK(HttpStatus.CONFLICT, "DUPLICATION_MEETING_LINK", "모임 링크가 중복되었습니다.");
 

--- a/src/main/java/com/dnd/snappy/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/dnd/snappy/domain/meeting/service/MeetingService.java
@@ -46,11 +46,11 @@ public class MeetingService {
     }
 
     @Transactional(readOnly = true)
-    public void validateMeetingLeaderAuthKey(Long meetingId, String password, String leaderAuthKey) {
+    public void validateMeetingLeaderAuthKey(Long meetingId, String leaderAuthKey) {
         Meeting meeting = findByMeetingIdOrThrow(meetingId);
 
-        if(!meeting.isLeaderAuthKeyValid(password, leaderAuthKey)) {
-            throw new BusinessException(MEETING_INVALIDATE_PASSWORD);
+        if(!meeting.isCorrectLeaderAuthKey(leaderAuthKey)) {
+            throw new BusinessException(MEETING_INVALIDATE_AUTH_KEY);
         }
     }
 

--- a/src/test/java/com/dnd/snappy/controller/v1/meeting/MeetingControllerTest.java
+++ b/src/test/java/com/dnd/snappy/controller/v1/meeting/MeetingControllerTest.java
@@ -219,11 +219,11 @@ class MeetingControllerTest extends RestDocsSupport {
                 .build();
         meeting = meetingRepository.save(meeting);
 
-        LeaderAuthKeyValidationRequest request = new LeaderAuthKeyValidationRequest(password, leaderAuthKey);
+        LeaderAuthKeyValidationRequest request = new LeaderAuthKeyValidationRequest(leaderAuthKey);
 
         //when //then
         mockMvc.perform(
-                        RestDocumentationRequestBuilders.post("/api/v1/meetings/{meetingId}/validate-password/leader", meeting.getId())
+                        RestDocumentationRequestBuilders.post("/api/v1/meetings/{meetingId}/validate-leader-key", meeting.getId())
                                 .content(objectMapper.writeValueAsString(request))
                                 .contentType(MediaType.APPLICATION_JSON)
                 )
@@ -234,61 +234,11 @@ class MeetingControllerTest extends RestDocsSupport {
                                         parameterWithName("meetingId").description("모임 ID")
                                 ),
                                 requestFields(
-                                        fieldWithPath("password").type(JsonFieldType.STRING).description("모임 비밀번호"),
                                         fieldWithPath("leaderAuthKey").type(JsonFieldType.STRING).description("관리자 인증키")
                                 ),
                                 responseFields(
                                         fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
                                         fieldWithPath("data").type(JsonFieldType.NULL).description("데이터")
-                                )
-                        )
-                );
-    }
-
-    @DisplayName("모임의 비밀번호가 유효하지 않다면 예외가 발생한다.")
-    @Test
-    void validateMeetingLeaderAuthKey_invalidatePassword() throws Exception {
-        //given
-        String password = "password";
-        String leaderAuthKey = "leaderAuthKey";
-        Meeting meeting = Meeting.builder()
-                .name("DND")
-                .description("DND 모임 입니다.")
-                .symbolColor("#FFF")
-                .thumbnailUrl("thumbnailUrl")
-                .startDate(LocalDateTime.now())
-                .endDate(LocalDateTime.now().plusDays(1))
-                .meetingLink("meetingLink")
-                .password(password)
-                .leaderAuthKey(leaderAuthKey)
-                .createdAt(LocalDateTime.now())
-                .updatedAt(LocalDateTime.now())
-                .build();
-        meeting = meetingRepository.save(meeting);
-
-        LeaderAuthKeyValidationRequest request = new LeaderAuthKeyValidationRequest("wrong password", leaderAuthKey);
-
-        //when //then
-        mockMvc.perform(
-                        RestDocumentationRequestBuilders.post("/api/v1/meetings/{meetingId}/validate-password/leader", meeting.getId())
-                                .content(objectMapper.writeValueAsString(request))
-                                .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadRequest())
-                .andDo(
-                        restDocs.document(
-                                pathParameters(
-                                        parameterWithName("meetingId").description("모임 ID")
-                                ),
-                                requestFields(
-                                        fieldWithPath("password").type(JsonFieldType.STRING).description("모임 비밀번호"),
-                                        fieldWithPath("leaderAuthKey").type(JsonFieldType.STRING).description("관리자 인증키")
-                                ),
-                                responseFields(
-                                        fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
-                                        fieldWithPath("data").type(JsonFieldType.NULL).description("데이터"),
-                                        fieldWithPath("error").type(JsonFieldType.OBJECT).description("에러"),
-                                        fieldWithPath("error.code").type(JsonFieldType.STRING).description("에러코드"),
-                                        fieldWithPath("error.message").type(JsonFieldType.STRING).description("에러 메세지")
                                 )
                         )
                 );
@@ -315,11 +265,11 @@ class MeetingControllerTest extends RestDocsSupport {
                 .build();
         meeting = meetingRepository.save(meeting);
 
-        LeaderAuthKeyValidationRequest request = new LeaderAuthKeyValidationRequest(password, "wrong leaderAuthKey");
+        LeaderAuthKeyValidationRequest request = new LeaderAuthKeyValidationRequest("wrong leaderAuthKey");
 
         //when //then
         mockMvc.perform(
-                        RestDocumentationRequestBuilders.post("/api/v1/meetings/{meetingId}/validate-password/leader", meeting.getId())
+                        RestDocumentationRequestBuilders.post("/api/v1/meetings/{meetingId}/validate-leader-key", meeting.getId())
                                 .content(objectMapper.writeValueAsString(request))
                                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest())
@@ -329,7 +279,6 @@ class MeetingControllerTest extends RestDocsSupport {
                                         parameterWithName("meetingId").description("모임 ID")
                                 ),
                                 requestFields(
-                                        fieldWithPath("password").type(JsonFieldType.STRING).description("모임 비밀번호"),
                                         fieldWithPath("leaderAuthKey").type(JsonFieldType.STRING).description("관리자 인증키")
                                 ),
                                 responseFields(

--- a/src/test/java/com/dnd/snappy/domain/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/com/dnd/snappy/domain/meeting/service/MeetingServiceTest.java
@@ -123,12 +123,8 @@ class MeetingServiceTest {
     }
 
     @DisplayName("모임의 관리자 인증키가 맞지 않다면 예외가 발생한다.")
-    @ParameterizedTest
-    @CsvSource({
-            "wrong password, leaderAuthKey",
-            "password, wrong leaderAuthKey"
-    })
-    void isCorrectMeetingPassword_invalidLeaderAuthKey(String requestPassword, String requestLeaderAuthKey) {
+    @Test
+    void isCorrectMeetingPassword_invalidLeaderAuthKey() {
         //given
         Long meetingId = 1L;
         String password = "password";
@@ -138,9 +134,9 @@ class MeetingServiceTest {
         given(meetingRepository.findById(meetingId)).willReturn(Optional.of(meeting));
 
         //when //then
-        assertThatThrownBy(() -> meetingService.validateMeetingLeaderAuthKey(meetingId, requestPassword, requestLeaderAuthKey))
+        assertThatThrownBy(() -> meetingService.validateMeetingLeaderAuthKey(meetingId, "wrong leaderAuthKey"))
                 .isInstanceOf(BusinessException.class)
-                .hasMessageStartingWith(MeetingErrorCode.MEETING_INVALIDATE_PASSWORD.getMessage());
+                .hasMessageStartingWith(MeetingErrorCode.MEETING_INVALIDATE_AUTH_KEY.getMessage());
 
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

관리자 인증키만 검증하는 api 구현했습니다

## 🚀 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

기존에 비밀번호와 관리자 인증키 동시에 검증한 api를 디자인 변경으로 관리자 인증키만 검증하게 변경했습니다!

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
