### PR TITLE
feat: mission 관련 엔티티 분리 및 MissionParticipant 엔티티 생성 (#48)

### DIFF
--- a/src/main/java/com/dnd/snappy/domain/mission/entity/MissionParticipant.java
+++ b/src/main/java/com/dnd/snappy/domain/mission/entity/MissionParticipant.java
@@ -1,8 +1,7 @@
 package com.dnd.snappy.domain.mission.entity;
 
 import com.dnd.snappy.domain.common.BaseEntity;
-import com.dnd.snappy.domain.meeting.entity.Meeting;
-import jakarta.persistence.Column;
+import com.dnd.snappy.domain.participant.entity.Participant;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
@@ -16,11 +15,13 @@ import lombok.experimental.SuperBuilder;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SuperBuilder(toBuilder = true)
-public class Mission extends BaseEntity {
-    @Column(nullable = false)
-    private String content;
+public class MissionParticipant extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "meeting_id", nullable = false)
-    private Meeting meeting;
+    @JoinColumn(name = "participant_id", nullable = false)
+    private Participant participant;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mission_id", nullable = false)
+    private Mission mission;
 }

--- a/src/main/java/com/dnd/snappy/domain/mission/entity/RandomMission.java
+++ b/src/main/java/com/dnd/snappy/domain/mission/entity/RandomMission.java
@@ -1,12 +1,11 @@
 package com.dnd.snappy.domain.mission.entity;
 
 import com.dnd.snappy.domain.common.BaseEntity;
-import com.dnd.snappy.domain.meeting.entity.Meeting;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,11 +15,10 @@ import lombok.experimental.SuperBuilder;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SuperBuilder(toBuilder = true)
-public class Mission extends BaseEntity {
+public class RandomMission {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
     @Column(nullable = false)
     private String content;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "meeting_id", nullable = false)
-    private Meeting meeting;
 }

--- a/src/main/java/com/dnd/snappy/domain/snap/entity/Snap.java
+++ b/src/main/java/com/dnd/snappy/domain/snap/entity/Snap.java
@@ -2,6 +2,7 @@ package com.dnd.snappy.domain.snap.entity;
 
 import com.dnd.snappy.domain.common.BaseEntity;
 import com.dnd.snappy.domain.meeting.entity.Meeting;
+import com.dnd.snappy.domain.mission.entity.RandomMission;
 import com.dnd.snappy.domain.participant.entity.Participant;
 import com.dnd.snappy.domain.mission.entity.Mission;
 import jakarta.persistence.Column;
@@ -32,6 +33,10 @@ public class Snap extends BaseEntity {
     private Meeting meeting;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "mission_id", nullable = false)
+    @JoinColumn(name = "mission_id")
     private Mission mission;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "random_mission_id")
+    private RandomMission randomMission;
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

close #48 

## 🚀 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

기존의 mission entity에서 랜덤 미션과 모임 미션 엔티티를 분리했습니다!
snap에 random_mission_id의 외래키를 추가해주었습니다.
특정 참가자가 어느 미션을 수행했는지 알기 위해 mission_participant 엔티티를 만들어주었습니다

랜덤 미션 엔티티 같은 경우 id값이 Long일 필요는 없다고 생각해서 Integer로 해주었습니다!

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
