### PR TITLE
[주최자] 모임 수정하기

### DIFF
--- a/src/docs/asciidoc/meeting/create-meeting.adoc
+++ b/src/docs/asciidoc/meeting/create-meeting.adoc
@@ -16,7 +16,7 @@ Response
 include::{snippets}/meeting-controller-test/create-meeting/http-response.adoc[]
 include::{snippets}/meeting-controller-test/create-meeting/response-fields.adoc[]
 
-==== 예외
+==== 실패
 ===== a. 모임 생성 시 필수 입력값을 입력하지 않으면 예외 메시지를 반환합니다.
 ====== - 대표 사진, 모임 종료일은 선택(모임 종료일 선택 x -> 시작일 + 1일로 설정)
 include::{snippets}/meeting-controller-test/create-meeting_validation_error/http-response.adoc[]

--- a/src/docs/asciidoc/meeting/meeting.adoc
+++ b/src/docs/asciidoc/meeting/meeting.adoc
@@ -14,3 +14,5 @@ include::validate-meeting-password-leader.adoc[]
 include::shareable-meeting-link.adoc[]
 
 include::find-meeting-password.adoc[]
+
+include::modify-meeting.adoc[]

--- a/src/docs/asciidoc/meeting/modify-meeting.adoc
+++ b/src/docs/asciidoc/meeting/modify-meeting.adoc
@@ -18,3 +18,7 @@ include::{snippets}/modify-meeting-controller-test/modify-meeting_invalid_input/
 `모임 리더가 아닌 참여자가 모임 정보를 수정하려 할 때 실패한다.`
 include::{snippets}/modify-meeting-controller-test/modify-meeting_unauthorized_meeting/http-response.adoc[]
 
+`모임 정보를 수정할 때 변경된 사항이 없는 경우 실패한다.`
+include::{snippets}/modify-meeting-controller-test/modify-meeting_no_changes/http-response.adoc[]
+
+

--- a/src/docs/asciidoc/meeting/modify-meeting.adoc
+++ b/src/docs/asciidoc/meeting/modify-meeting.adoc
@@ -1,0 +1,20 @@
+=== 모임 수정
+==== 성공
+==== 요청 형식
+
+Request
+include::{snippets}/modify-meeting-controller-test/modify-meeting/http-request.adoc[]
+include::{snippets}/modify-meeting-controller-test/modify-meeting/path-parameters.adoc[]
+
+Response
+include::{snippets}/modify-meeting-controller-test/modify-meeting/http-response.adoc[]
+include::{snippets}/modify-meeting-controller-test/modify-meeting/response-fields.adoc[]
+
+
+==== 실패
+`유효하지 않은 입력 데이터로 모임 수정 시 실패한다.`
+include::{snippets}/modify-meeting-controller-test/modify-meeting_invalid_input/http-response.adoc[]
+
+`모임 리더가 아닌 참여자가 모임 정보를 수정하려 할 때 실패한다.`
+include::{snippets}/modify-meeting-controller-test/modify-meeting_unauthorized_meeting/http-response.adoc[]
+

--- a/src/main/java/com/dnd/snappy/controller/v1/meeting/ModifyMeetingController.java
+++ b/src/main/java/com/dnd/snappy/controller/v1/meeting/ModifyMeetingController.java
@@ -1,0 +1,30 @@
+package com.dnd.snappy.controller.v1.meeting;
+
+import com.dnd.snappy.common.dto.ResponseDto;
+import com.dnd.snappy.controller.v1.auth.resolver.AuthInfo;
+import com.dnd.snappy.controller.v1.auth.resolver.AuthPrincipal;
+import com.dnd.snappy.domain.meeting.dto.request.ModifyMeetingRequestDto;
+import com.dnd.snappy.domain.meeting.dto.response.ModifyMeetingResponseDto;
+import com.dnd.snappy.domain.meeting.service.ModifyMeetingService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/meetings/{meetingId}")
+@RequiredArgsConstructor
+public class ModifyMeetingController {
+
+    private final ModifyMeetingService modifyMeetingService;
+
+    @PatchMapping()
+    public ResponseEntity<ResponseDto<ModifyMeetingResponseDto>> modifyMeeting(
+            @PathVariable Long meetingId,
+            @AuthPrincipal AuthInfo authInfo,
+            @Valid @RequestBody ModifyMeetingRequestDto requestDto
+    ) {
+        var response = modifyMeetingService.modifyMeeting(meetingId, authInfo.participantId(), requestDto);
+        return ResponseDto.ok(response);
+    }
+}

--- a/src/main/java/com/dnd/snappy/domain/meeting/dto/request/ModifyMeetingRequestDto.java
+++ b/src/main/java/com/dnd/snappy/domain/meeting/dto/request/ModifyMeetingRequestDto.java
@@ -1,0 +1,16 @@
+package com.dnd.snappy.domain.meeting.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ModifyMeetingRequestDto(
+
+        @Size(min = 3, max = 15, message = "모임명은 3자 이상 15자 이하이어야 합니다.")
+        String name,
+
+        @Size(min = 8, max = 150, message = "모임 설명은 8자 이상 150자 이내여야 합니다.")
+        String description,
+
+        String symbolColor
+) {
+}

--- a/src/main/java/com/dnd/snappy/domain/meeting/dto/response/ModifyMeetingResponseDto.java
+++ b/src/main/java/com/dnd/snappy/domain/meeting/dto/response/ModifyMeetingResponseDto.java
@@ -1,0 +1,9 @@
+package com.dnd.snappy.domain.meeting.dto.response;
+
+public record ModifyMeetingResponseDto(
+        Long MeetingId,
+        String name,
+        String description,
+        String symbolColor
+) {
+}

--- a/src/main/java/com/dnd/snappy/domain/meeting/dto/response/ModifyMeetingResponseDto.java
+++ b/src/main/java/com/dnd/snappy/domain/meeting/dto/response/ModifyMeetingResponseDto.java
@@ -1,7 +1,7 @@
 package com.dnd.snappy.domain.meeting.dto.response;
 
 public record ModifyMeetingResponseDto(
-        Long MeetingId,
+        Long meetingId,
         String name,
         String description,
         String symbolColor

--- a/src/main/java/com/dnd/snappy/domain/meeting/entity/Meeting.java
+++ b/src/main/java/com/dnd/snappy/domain/meeting/entity/Meeting.java
@@ -117,16 +117,23 @@ public class Meeting extends BaseEntity {
         }
     }
 
-    public void modifyMeeting(ModifyMeetingRequestDto dto) {
-        if (dto.name() != null) {
+    public boolean modifyMeeting(ModifyMeetingRequestDto dto) {
+        boolean isModified = false;
+
+        if (dto.name() != null && !dto.name().equals(this.name)) {
             this.name = dto.name();
+            isModified = true;
         }
-        if (dto.description() != null) {
+        if (dto.description() != null && !dto.description().equals(this.description)) {
             this.description = dto.description();
+            isModified = true;
         }
-        if (dto.symbolColor() != null) {
+        if (dto.symbolColor() != null && !dto.symbolColor().equals(this.symbolColor)) {
             this.symbolColor = dto.symbolColor();
+            isModified = true;
         }
+
+        return isModified;
     }
 
 }

--- a/src/main/java/com/dnd/snappy/domain/meeting/entity/Meeting.java
+++ b/src/main/java/com/dnd/snappy/domain/meeting/entity/Meeting.java
@@ -4,7 +4,7 @@ import com.dnd.snappy.common.error.CommonErrorCode;
 import com.dnd.snappy.common.error.exception.BusinessException;
 import com.dnd.snappy.domain.common.BaseEntity;
 import com.dnd.snappy.domain.meeting.dto.request.CreateMeetingEntityDto;
-import com.dnd.snappy.domain.meeting.dto.request.CreateMeetingRequestDto;
+import com.dnd.snappy.domain.meeting.dto.request.ModifyMeetingRequestDto;
 import com.dnd.snappy.domain.meeting.exception.MeetingErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -116,4 +116,17 @@ public class Meeting extends BaseEntity {
             throw new BusinessException(MeetingErrorCode.NO_IN_PROGRESS_MEETING);
         }
     }
+
+    public void modifyMeeting(ModifyMeetingRequestDto dto) {
+        if (dto.name() != null) {
+            this.name = dto.name();
+        }
+        if (dto.description() != null) {
+            this.description = dto.description();
+        }
+        if (dto.symbolColor() != null) {
+            this.symbolColor = dto.symbolColor();
+        }
+    }
+
 }

--- a/src/main/java/com/dnd/snappy/domain/meeting/exception/MeetingErrorCode.java
+++ b/src/main/java/com/dnd/snappy/domain/meeting/exception/MeetingErrorCode.java
@@ -17,7 +17,7 @@ public enum MeetingErrorCode implements ErrorCodeInterface {
     DUPLICATION_MEETING_LINK(HttpStatus.CONFLICT, "DUPLICATION_MEETING_LINK", "모임 링크가 중복되었습니다."),
     NO_IN_PROGRESS_MEETING(HttpStatus.FORBIDDEN, "NO_IN_PROGRESS_MEETING", "진행중인 모임이 아닙니다."),
     UNAUTHORIZED_MEETING(HttpStatus.FORBIDDEN, "UNAUTHORIZED_MEETING", "모임 수정 권한이 없습니다."),
-    ;
+    NO_MODIFICATION(HttpStatus.BAD_REQUEST, "NO_MODIFICATION", "변경된 수정 사항이 없습니다.");
 
     private final HttpStatus status;
 

--- a/src/main/java/com/dnd/snappy/domain/meeting/exception/MeetingErrorCode.java
+++ b/src/main/java/com/dnd/snappy/domain/meeting/exception/MeetingErrorCode.java
@@ -15,7 +15,9 @@ public enum MeetingErrorCode implements ErrorCodeInterface {
     MEETING_INVALIDATE_AUTH_KEY(HttpStatus.BAD_REQUEST, "MEETING_INVALIDATE_AUTH_KEY", "모임의 관리자 인증키가 유효하지 않습니다."),
     MEETING_JOIN_DENIED(HttpStatus.FORBIDDEN, "MEETING_JOIN_DENIED", "이미 끝난 모임에는 참여할 수 없습니다."),
     DUPLICATION_MEETING_LINK(HttpStatus.CONFLICT, "DUPLICATION_MEETING_LINK", "모임 링크가 중복되었습니다."),
-    NO_IN_PROGRESS_MEETING(HttpStatus.FORBIDDEN, "NO_IN_PROGRESS_MEETING", "진행중인 모임이 아닙니다.");
+    NO_IN_PROGRESS_MEETING(HttpStatus.FORBIDDEN, "NO_IN_PROGRESS_MEETING", "진행중인 모임이 아닙니다."),
+    UNAUTHORIZED_MEETING(HttpStatus.FORBIDDEN, "UNAUTHORIZED_MEETING", "모임 수정 권한이 없습니다."),
+    ;
 
     private final HttpStatus status;
 

--- a/src/main/java/com/dnd/snappy/domain/meeting/service/ModifyMeetingService.java
+++ b/src/main/java/com/dnd/snappy/domain/meeting/service/ModifyMeetingService.java
@@ -28,6 +28,10 @@ public class ModifyMeetingService {
 
         validateLeader(participant, meetingId);
 
+        if (!meeting.modifyMeeting(requestDto)) {
+            throw new BusinessException(MeetingErrorCode.NO_MODIFICATION);
+        }
+
         meeting.modifyMeeting(requestDto);
 
         return new ModifyMeetingResponseDto(meeting.getId(), meeting.getName(), meeting.getDescription(), meeting.getSymbolColor());

--- a/src/main/java/com/dnd/snappy/domain/meeting/service/ModifyMeetingService.java
+++ b/src/main/java/com/dnd/snappy/domain/meeting/service/ModifyMeetingService.java
@@ -1,0 +1,52 @@
+package com.dnd.snappy.domain.meeting.service;
+
+import com.dnd.snappy.common.error.exception.BusinessException;
+import com.dnd.snappy.common.error.exception.NotFoundException;
+import com.dnd.snappy.domain.meeting.dto.request.ModifyMeetingRequestDto;
+import com.dnd.snappy.domain.meeting.dto.response.ModifyMeetingResponseDto;
+import com.dnd.snappy.domain.meeting.entity.Meeting;
+import com.dnd.snappy.domain.meeting.exception.MeetingErrorCode;
+import com.dnd.snappy.domain.meeting.repository.MeetingRepository;
+import com.dnd.snappy.domain.participant.entity.Participant;
+import com.dnd.snappy.domain.participant.exception.ParticipantErrorCode;
+import com.dnd.snappy.domain.participant.repository.ParticipantRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ModifyMeetingService {
+    private final ParticipantRepository participantRepository;
+    private final MeetingRepository meetingRepository;
+
+    @Transactional
+    public ModifyMeetingResponseDto modifyMeeting(Long meetingId, Long participantId, ModifyMeetingRequestDto requestDto) {
+        Meeting meeting = findByMeetingIdOrThrow(meetingId);
+        Participant participant = findParticipantByIdOrThrow(participantId);
+
+        validateLeader(participant, meetingId);
+
+        meeting.modifyMeeting(requestDto);
+
+        return new ModifyMeetingResponseDto(meeting.getId(), meeting.getName(), meeting.getDescription(), meeting.getSymbolColor());
+    }
+
+    private Meeting findByMeetingIdOrThrow(Long meetingId) {
+        return meetingRepository.findById(meetingId)
+                .orElseThrow(() -> new NotFoundException(MeetingErrorCode.MEETING_NOT_FOUND, meetingId));
+    }
+
+    private Participant findParticipantByIdOrThrow(Long participantId) {
+        return participantRepository.findById(participantId)
+                .orElseThrow(() -> new NotFoundException(ParticipantErrorCode.NOT_PARTICIPATING_MEETING, participantId));
+    }
+
+    private void validateLeader(Participant participant, Long meetingId) {
+        if (!participant.isLeader(meetingId)) {
+            throw new BusinessException(MeetingErrorCode.UNAUTHORIZED_MEETING);
+        }
+    }
+
+}

--- a/src/test/java/com/dnd/snappy/controller/v1/meeting/ModifyMeetingControllerTest.java
+++ b/src/test/java/com/dnd/snappy/controller/v1/meeting/ModifyMeetingControllerTest.java
@@ -184,6 +184,34 @@ class ModifyMeetingControllerTest extends RestDocsSupport {
                 );
     }
 
+    @DisplayName("모임 정보를 수정할 때 변경된 사항이 없는 경우 실패한다.")
+    @Test
+    void modifyMeeting_NO_CHANGES() throws Exception {
+        // given
+        Meeting meeting = createMeeting();
+
+        Participant leader = createParticipant(meeting, Role.LEADER);
+        Tokens leaderTokens = tokenProvider.issueTokens(leader.getId());
+        String leaderAccessTokenCookieName = authTokenCookieNameGenerator.generateCookieName(TokenType.ACCESS_TOKEN, meeting.getId());
+        String leaderAccessToken = leaderTokens.accessToken();
+
+        ModifyMeetingRequestDto modifyRequestDto = new ModifyMeetingRequestDto(meeting.getName(), meeting.getDescription(), meeting.getSymbolColor());
+
+        // when & then
+        mockMvc.perform(
+                        patch("/api/v1/meetings/{meetingId}", meeting.getId())
+                                .cookie(new Cookie(leaderAccessTokenCookieName, leaderAccessToken))
+                                .content(objectMapper.writeValueAsString(modifyRequestDto))
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isBadRequest())
+                .andDo(
+                        restDocs.document(
+                                getErrorResponseFields()
+                        )
+                );
+    }
+
     private Meeting createMeeting() {
         Meeting meeting = Meeting.builder()
                 .name("DND")

--- a/src/test/java/com/dnd/snappy/controller/v1/meeting/ModifyMeetingControllerTest.java
+++ b/src/test/java/com/dnd/snappy/controller/v1/meeting/ModifyMeetingControllerTest.java
@@ -1,0 +1,223 @@
+package com.dnd.snappy.controller.v1.meeting;
+
+import com.dnd.snappy.domain.auth.service.AuthTokenCookieNameGenerator;
+import com.dnd.snappy.domain.meeting.dto.request.ModifyMeetingRequestDto;
+import com.dnd.snappy.domain.meeting.entity.Meeting;
+import com.dnd.snappy.domain.meeting.repository.MeetingRepository;
+import com.dnd.snappy.domain.participant.entity.Participant;
+import com.dnd.snappy.domain.participant.entity.Role;
+import com.dnd.snappy.domain.participant.repository.ParticipantRepository;
+import com.dnd.snappy.domain.token.dto.Tokens;
+import com.dnd.snappy.domain.token.service.TokenProvider;
+import com.dnd.snappy.domain.token.service.TokenType;
+import com.dnd.snappy.support.RestDocsSupport;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.restdocs.payload.ResponseFieldsSnippet;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Transactional
+class ModifyMeetingControllerTest extends RestDocsSupport {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private AuthTokenCookieNameGenerator authTokenCookieNameGenerator;
+
+    @Autowired
+    private TokenProvider tokenProvider;
+
+    @Autowired
+    private MeetingRepository meetingRepository;
+
+    @Autowired
+    private ParticipantRepository participantRepository;
+
+    @DisplayName("모임 리더는 모임 정보를 수정한다.")
+    @Test
+    void modifyMeeting() throws Exception {
+        // given
+        Meeting meeting = createMeeting();
+        Participant leader = createParticipant(meeting, Role.LEADER);
+
+        ModifyMeetingRequestDto modifyRequestDto = new ModifyMeetingRequestDto("수정된 모임 이름", "수정된 모임 설명", "#000000");
+
+        Tokens tokens = tokenProvider.issueTokens(leader.getId());
+        String accessTokenCookieName = authTokenCookieNameGenerator.generateCookieName(TokenType.ACCESS_TOKEN, meeting.getId());
+        String accessToken = tokens.accessToken();
+
+        // when & then
+        mockMvc.perform(
+                        patch("/api/v1/meetings/{meetingId}", meeting.getId())
+                                .cookie(new Cookie(accessTokenCookieName, accessToken))
+                                .content(objectMapper.writeValueAsString(modifyRequestDto))
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andDo(
+                        restDocs.document(
+                                pathParameters(
+                                        parameterWithName("meetingId").description("모임 ID")
+                                ),
+                                requestFields(
+                                        fieldWithPath("name").type(JsonFieldType.STRING).description("수정된 모임 이름").optional(),
+                                        fieldWithPath("description").type(JsonFieldType.STRING).description("수정된 모임 설명").optional(),
+                                        fieldWithPath("symbolColor").type(JsonFieldType.STRING).description("수정된 모임 색상").optional()
+                                ),
+                                responseFields(
+                                        fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                                        fieldWithPath("data.meetingId").type(JsonFieldType.NUMBER).description("모임 ID"),
+                                        fieldWithPath("data.name").type(JsonFieldType.STRING).description("수정된 모임 이름"),
+                                        fieldWithPath("data.description").type(JsonFieldType.STRING).description("수정된 모임 설명"),
+                                        fieldWithPath("data.symbolColor").type(JsonFieldType.STRING).description("수정된 모임 색상")
+                                )
+                        )
+                );
+    }
+
+    @DisplayName("유효하지 않은 입력 데이터로 모임 수정 시 실패한다.")
+    @Test
+    void modifyMeeting_INVALID_INPUT() throws Exception {
+        // given
+        Meeting meeting = createMeeting();
+        Participant leader = createParticipant(meeting, Role.LEADER);
+
+        List<ModifyMeetingRequestDto> invalidRequestDtos = List.of(
+                new ModifyMeetingRequestDto("", null, null),
+                new ModifyMeetingRequestDto("ab", "설명", "#000000"),
+                new ModifyMeetingRequestDto("a".repeat(101), "설명", "#000000")
+        );
+
+        Tokens tokens = tokenProvider.issueTokens(leader.getId());
+        String accessTokenCookieName = authTokenCookieNameGenerator.generateCookieName(TokenType.ACCESS_TOKEN, meeting.getId());
+        String accessToken = tokens.accessToken();
+
+        for (ModifyMeetingRequestDto requestDto : invalidRequestDtos) {
+            // when & then
+            mockMvc.perform(
+                            patch("/api/v1/meetings/{meetingId}", meeting.getId())
+                                    .cookie(new Cookie(accessTokenCookieName, accessToken))
+                                    .content(objectMapper.writeValueAsString(requestDto))
+                                    .contentType(MediaType.APPLICATION_JSON)
+                    )
+                    .andExpect(status().isBadRequest())
+                    .andDo(
+                            restDocs.document(
+                                    getErrorResponseFields()
+                            )
+                    );
+        }
+    }
+
+    @DisplayName("모임 리더가 아닌 사용자가 모임 정보를 수정하려 할 때 실패한다.")
+    @Test
+    void modifyMeeting_UNAUTHORIZED_MEETING() throws Exception {
+        // given
+        Meeting meeting = createMeeting();
+
+        Participant leader = createParticipant(meeting, Role.LEADER);
+        Tokens leaderTokens = tokenProvider.issueTokens(leader.getId());
+        String leaderAccessTokenCookieName = authTokenCookieNameGenerator.generateCookieName(TokenType.ACCESS_TOKEN, meeting.getId());
+        String leaderAccessToken = leaderTokens.accessToken();
+
+        ModifyMeetingRequestDto modifyRequestDto = new ModifyMeetingRequestDto("수정된 모임 이름", "수정된 모임 설명", "#000000");
+
+        mockMvc.perform(
+                        patch("/api/v1/meetings/{meetingId}", meeting.getId())
+                                .cookie(new Cookie(leaderAccessTokenCookieName, leaderAccessToken))
+                                .content(objectMapper.writeValueAsString(modifyRequestDto))
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andDo(
+                        restDocs.document(
+                                pathParameters(
+                                        parameterWithName("meetingId").description("모임 ID")
+                                ),
+                                requestFields(
+                                        fieldWithPath("name").type(JsonFieldType.STRING).description("수정된 모임 이름"),
+                                        fieldWithPath("description").type(JsonFieldType.STRING).description("수정된 모임 설명"),
+                                        fieldWithPath("symbolColor").type(JsonFieldType.STRING).description("수정된 모임 색상")
+                                ),
+                                responseFields(
+                                        fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                                        fieldWithPath("data.meetingId").type(JsonFieldType.NUMBER).description("수정된 모임 ID"),
+                                        fieldWithPath("data.name").type(JsonFieldType.STRING).description("수정된 모임 이름"),
+                                        fieldWithPath("data.description").type(JsonFieldType.STRING).description("수정된 모임 설명"),
+                                        fieldWithPath("data.symbolColor").type(JsonFieldType.STRING).description("수정된 모임 색상")
+                                )
+                        )
+                );
+
+        Participant participant = createParticipant(meeting, Role.PARTICIPANT);
+        Tokens participantTokens = tokenProvider.issueTokens(participant.getId());
+        String participantAccessTokenCookieName = authTokenCookieNameGenerator.generateCookieName(TokenType.ACCESS_TOKEN, meeting.getId());
+        String participantAccessToken = participantTokens.accessToken();
+
+        // when & then
+        mockMvc.perform(
+                        patch("/api/v1/meetings/{meetingId}", meeting.getId())
+                                .cookie(new Cookie(participantAccessTokenCookieName, participantAccessToken))
+                                .content(objectMapper.writeValueAsString(modifyRequestDto))
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isForbidden())
+                .andDo(
+                        restDocs.document(
+                                getErrorResponseFields()
+                        )
+                );
+    }
+
+    private Meeting createMeeting() {
+        Meeting meeting = Meeting.builder()
+                .name("DND")
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now())
+                .symbolColor("#fff")
+                .meetingLink("link")
+                .password("1234")
+                .leaderAuthKey("1234")
+                .build();
+        return meetingRepository.save(meeting);
+    }
+
+    private Participant createParticipant(Meeting meeting, Role role) {
+        Participant participant = Participant.builder()
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .meeting(meeting)
+                .nickname("nick")
+                .role(role)
+                .shootCount(10)
+                .build();
+        return participantRepository.save(participant);
+    }
+
+    private ResponseFieldsSnippet getErrorResponseFields() {
+        return responseFields(
+                fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                fieldWithPath("data").type(JsonFieldType.NULL).description("데이터"),
+                fieldWithPath("error").type(JsonFieldType.OBJECT).description("에러"),
+                fieldWithPath("error.code").type(JsonFieldType.STRING).description("에러 코드"),
+                fieldWithPath("error.message").type(JsonFieldType.STRING).description("에러 메세지")
+        );
+    }
+}

--- a/src/test/java/com/dnd/snappy/domain/meeting/service/ModifyMeetingServiceTest.java
+++ b/src/test/java/com/dnd/snappy/domain/meeting/service/ModifyMeetingServiceTest.java
@@ -1,0 +1,141 @@
+package com.dnd.snappy.domain.meeting.service;
+
+import com.dnd.snappy.common.error.exception.BusinessException;
+import com.dnd.snappy.common.error.exception.NotFoundException;
+import com.dnd.snappy.domain.meeting.dto.request.ModifyMeetingRequestDto;
+import com.dnd.snappy.domain.meeting.dto.response.ModifyMeetingResponseDto;
+import com.dnd.snappy.domain.meeting.entity.Meeting;
+import com.dnd.snappy.domain.meeting.repository.MeetingRepository;
+import com.dnd.snappy.domain.participant.entity.Participant;
+import com.dnd.snappy.domain.participant.entity.Role;
+import com.dnd.snappy.domain.participant.repository.ParticipantRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+
+@ExtendWith(MockitoExtension.class)
+class ModifyMeetingServiceTest {
+
+    @InjectMocks
+    private ModifyMeetingService modifyMeetingService;
+
+    @Mock
+    private MeetingRepository meetingRepository;
+
+    @Mock
+    private ParticipantRepository participantRepository;
+
+    @DisplayName("모임 리더가 모임 정보를 수정한다.")
+    @Test
+    void modifyMeeting_Success() {
+        // given
+        Long meetingId = 1L;
+        Long participantId = 1L;
+        String newName = "수정된 모임 이름";
+        String newDescription = "수정된 모임 설명";
+        String newSymbolColor = "#ff0000";
+
+        ModifyMeetingRequestDto requestDto = new ModifyMeetingRequestDto(newName, newDescription, newSymbolColor);
+
+        Meeting meeting = Meeting.builder()
+                .id(meetingId)
+                .name("기존 모임 이름")
+                .description("기존 모임 설명")
+                .symbolColor("#ffffff")
+                .build();
+
+        Participant participant = Participant.builder()
+                .id(participantId)
+                .nickname("리더")
+                .role(Role.LEADER)
+                .meeting(meeting)
+                .build();
+
+        given(meetingRepository.findById(meetingId)).willReturn(Optional.of(meeting));
+        given(participantRepository.findById(participantId)).willReturn(Optional.of(participant));
+
+        // when
+        ModifyMeetingResponseDto response = modifyMeetingService.modifyMeeting(meetingId, participantId, requestDto);
+
+        // then
+        assertThat(response.name()).isEqualTo(newName);
+        assertThat(response.description()).isEqualTo(newDescription);
+        assertThat(response.symbolColor()).isEqualTo(newSymbolColor);
+    }
+
+    @DisplayName("참여하지 않은 모임 ID로 모임을 수정하려 할 때 예외가 발생한다.")
+    @Test
+    void modifyMeeting_MeetingNotFound() {
+        // given
+        Long meetingId = 1L;
+        Long participantId = 2L;
+        ModifyMeetingRequestDto requestDto = new ModifyMeetingRequestDto("새 이름", "새 설명", "#ff0000");
+
+        given(meetingRepository.findById(meetingId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> modifyMeetingService.modifyMeeting(meetingId, participantId, requestDto))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("요청된 모임을 찾을 수 없습니다.");
+    }
+
+    @DisplayName("리더가 아닌 참여자가 모임을 수정하려 할 때 예외가 발생한다.")
+    @Test
+    void modifyMeeting_Unauthorized() {
+        // given
+        Long meetingId = 1L;
+        Long participantId = 2L;
+        ModifyMeetingRequestDto requestDto = new ModifyMeetingRequestDto("새 이름", "새 설명", "#ff0000");
+
+        Meeting meeting = Meeting.builder().id(meetingId).build();
+        Participant participant = Participant.builder()
+                .id(participantId)
+                .nickname("참여자")
+                .role(Role.PARTICIPANT)
+                .meeting(meeting)
+                .build();
+
+        given(meetingRepository.findById(meetingId)).willReturn(Optional.of(meeting));
+        given(participantRepository.findById(participantId)).willReturn(Optional.of(participant));
+
+        // when & then
+        assertThatThrownBy(() -> modifyMeetingService.modifyMeeting(meetingId, participantId, requestDto))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("모임 수정 권한이 없습니다.");
+    }
+
+    @DisplayName("모임 리더가 아닌 사용자가 수정 시 예외가 발생한다.")
+    @Test
+    void modifyMeeting_LeaderValidationFailure() {
+        // given
+        Long meetingId = 1L;
+        Long participantId = 2L;
+        ModifyMeetingRequestDto requestDto = new ModifyMeetingRequestDto("새 이름", "새 설명", "#ff0000");
+
+        Meeting meeting = Meeting.builder().id(meetingId).build();
+        Participant participant = Participant.builder()
+                .id(participantId)
+                .nickname("참여자")
+                .role(Role.PARTICIPANT)
+                .meeting(meeting)
+                .build();
+
+        given(meetingRepository.findById(meetingId)).willReturn(Optional.of(meeting));
+        given(participantRepository.findById(participantId)).willReturn(Optional.of(participant));
+
+        // when & then
+        assertThatThrownBy(() -> modifyMeetingService.modifyMeeting(meetingId, participantId, requestDto))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("모임 수정 권한이 없습니다.");
+    }
+}

--- a/src/test/java/com/dnd/snappy/domain/mission/service/MissionValidationServiceTest.java
+++ b/src/test/java/com/dnd/snappy/domain/mission/service/MissionValidationServiceTest.java
@@ -1,0 +1,179 @@
+package com.dnd.snappy.domain.mission.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.BDDMockito.*;
+
+import com.dnd.snappy.common.error.exception.BusinessException;
+import com.dnd.snappy.common.error.exception.NotFoundException;
+import com.dnd.snappy.domain.meeting.entity.Meeting;
+import com.dnd.snappy.domain.mission.entity.Mission;
+import com.dnd.snappy.domain.mission.repository.MissionParticipantRepository;
+import com.dnd.snappy.domain.mission.repository.MissionRepository;
+import com.dnd.snappy.domain.participant.entity.Participant;
+import com.dnd.snappy.domain.participant.entity.Role;
+import com.dnd.snappy.domain.participant.repository.ParticipantRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+@ExtendWith(MockitoExtension.class)
+class MissionValidationServiceTest {
+
+    @InjectMocks
+    private MissionValidationService missionValidationService;
+
+    @Mock
+    private MissionParticipantRepository missionParticipantRepository;
+
+    @Mock
+    private ParticipantRepository participantRepository;
+
+    @Mock
+    private MissionRepository missionRepository;
+
+    @DisplayName("리더가 맞는 경우 validateIsLeader는 성공한다.")
+    @Test
+    void validateIsLeader_Success() {
+        // given
+        Long meetingId = 1L;
+        Long participantId = 1L;
+
+        Participant participant = Participant.builder()
+                .id(participantId)
+                .role(Role.LEADER)
+                .meeting(Meeting.builder().id(meetingId).build())
+                .build();
+
+        given(participantRepository.findById(participantId)).willReturn(Optional.of(participant));
+
+        // when & then
+        assertDoesNotThrow(() -> missionValidationService.validateIsLeader(participantId, meetingId));
+    }
+
+    @DisplayName("리더가 아닌 경우 예외를 던진다.")
+    @Test
+    void validateIsLeader_exception() {
+        // given
+        Long meetingId = 1L;
+        Long participantId = 1L;
+
+        Participant participant = Participant.builder()
+                .id(participantId)
+                .role(Role.PARTICIPANT)
+                .meeting(Meeting.builder().id(meetingId).build())
+                .build();
+
+        given(participantRepository.findById(participantId)).willReturn(Optional.of(participant));
+
+        // when & then
+        assertThatThrownBy(() -> missionValidationService.validateIsLeader(participantId, meetingId))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("모임 미션 생성/수정/삭제 권한이 없습니다.");
+    }
+
+    @DisplayName("모집에 참여하는 참여자Id가 존재하지 않을 경우 예외를 던진다.")
+    @Test
+    void validateIsLeader_ParticipantNotFound() {
+        // given
+        Long meetingId = 1L;
+        Long participantId = 1L;
+
+        given(participantRepository.findById(participantId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> missionValidationService.validateIsLeader(participantId, meetingId))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("모임에 참여중인 참가자가 아닙니다.");
+    }
+
+    @DisplayName("미션에 참여자가 있을 경우 미션을 수정하려 할 시, 예외를 던진다.")
+    @Test
+    void validateModification_MissionHasParticipants() {
+        // given
+        Long meetingId = 1L;
+        Long participantId = 1L;
+        Long missionId = 1L;
+        String newContent = "새 내용";
+
+        Mission mission = Mission.builder()
+                .id(missionId)
+                .content("기존 내용")
+                .meeting(Meeting.builder().id(meetingId).build())
+                .build();
+
+        given(missionParticipantRepository.existsByMissionId(missionId)).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> missionValidationService.validateModification(mission, newContent, participantId, meetingId))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("미션에 참여자가 있어서 수정/삭제할 수 없습니다.");
+    }
+
+    @DisplayName("미션 내용이 변경되지 않은 경우 예외를 던진다.")
+    @Test
+    void validateModification_Unchanged() {
+        // given
+        Long meetingId = 1L;
+        Long participantId = 1L;
+        Long missionId = 1L;
+        String newContent = "기존 내용";
+
+        Mission mission = Mission.builder()
+                .id(missionId)
+                .content("기존 내용")
+                .meeting(Meeting.builder().id(meetingId).build())
+                .build();
+
+        lenient().when(missionParticipantRepository.existsByMissionId(missionId)).thenReturn(false);
+        lenient().when(missionRepository.findById(missionId)).thenReturn(Optional.of(mission));
+        lenient().when(participantRepository.findById(participantId)).thenReturn(Optional.of(Participant.builder()
+                .id(participantId)
+                .role(Role.LEADER)
+                .meeting(Meeting.builder().id(meetingId).build())
+                .build()));
+
+        // when & then
+        assertThatThrownBy(() -> missionValidationService.validateModification(mission, newContent, participantId, meetingId))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("변경된 사항이 없습니다.");
+    }
+
+    @DisplayName("미션에 참여자가 있을 경우 예외를 던진다.")
+    @Test
+    void validateMissionForDeletion_MissionHasParticipants() {
+        // given
+        Long meetingId = 1L;
+        Long participantId = 1L;
+        Long missionId = 1L;
+
+        given(missionParticipantRepository.existsByMissionId(missionId)).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> missionValidationService.validateMissionForDeletion(missionId, participantId, meetingId))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("미션에 참여자가 있어서 수정/삭제할 수 없습니다.");
+    }
+
+    @DisplayName("존재하지 않는 미션 ID로 시도할 시 예외를 던진다.")
+    @Test
+    void validateMissionForDeletion_MissionNotFound() {
+        // given
+        Long meetingId = 1L;
+        Long participantId = 1L;
+        Long missionId = 1L;
+
+        given(missionParticipantRepository.existsByMissionId(missionId)).willReturn(false);
+        given(missionRepository.findById(missionId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> missionValidationService.validateMissionForDeletion(missionId, participantId, meetingId))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("미션이 존재하지 않습니다.");
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #30 

## 🚀 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 주최자의 모임 수정 기능 (이름, 소개, 테마 색상) 구현하였고, 유효성은 일부만 수정도 가능한 것 같아서 모든 값을 입력하지 않아도 수정 되도록 구현하였습니다.
- 미션 검증 로직 단위 테스트

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
